### PR TITLE
Fix for tput with uninformative output

### DIFF
--- a/R/has_color.r
+++ b/R/has_color.r
@@ -76,10 +76,9 @@ num_colors <- function(forget = FALSE) {
 
 i_num_colors <- memoise::memoise(function() {
   if (!has_color()) { return(1) }
-  cols <- try(silent = TRUE,
-              system("tput colors", intern = TRUE))
-  if (inherits(cols, "try-error")) { return(8) }
-  cols <- as.numeric(cols)
+  cols <- suppressWarnings(try(silent = TRUE,
+              as.numeric(system("tput colors", intern = TRUE))))
+  if (inherits(cols, "try-error") || is.na(cols)) { return(8) }
   if (cols %in% c(0, 1)) { return(1) }
   cols
 })


### PR DESCRIPTION
The tput installed on winbuilder gives an 'unknown terminal "cygwin"'
error on STDERR, but returns nothing on STDOUT and returns an error code
of 0.  Therefore the result cannot be coerced to a number and
cols returns character(0).

`character(0) %in% c(0, 1)` returns `logical(0)`, and `logical(0)` in an if
statement yields the fairly useless error message 'error: argument is of
length zero'

This situation results in crayon being unable to load.  The fix handles
the above situation as well as the situation where tput does return
something on STDOUT, but that value cannot be coerced to a number (and
returns NA).

Fixes #18