### PR TITLE
Need to check the length before NA

### DIFF
--- a/R/has_color.r
+++ b/R/has_color.r
@@ -78,7 +78,7 @@ i_num_colors <- memoise::memoise(function() {
   if (!has_color()) { return(1) }
   cols <- suppressWarnings(try(silent = TRUE,
               as.numeric(system("tput colors", intern = TRUE))))
-  if (inherits(cols, "try-error") || is.na(cols)) { return(8) }
+  if (inherits(cols, "try-error") || !length(cols) || is.na(cols)) { return(8) }
   if (cols %in% c(0, 1)) { return(1) }
   cols
 })

--- a/tests/testthat/test-has-color.r
+++ b/tests/testthat/test-has-color.r
@@ -27,3 +27,34 @@ test_that("number of colors is detected", {
   expect_equal(nc, as.integer(nc))
 
 })
+
+test_that("tput errors are handled gracefully", {
+
+  # if tput errors num_colors is 8
+  with_mock(
+            `base::system` = function(...) stop("Error!"),
+
+            expect_equal(num_colors(forget = TRUE), 8)
+            )
+
+  # if tput returns nothing num_colors is 8
+  with_mock(
+            `base::system` = function(...) character(0),
+
+            expect_equal(num_colors(forget = TRUE), 8)
+            )
+
+  # if tput returns a non-number num_colors is 8
+  with_mock(
+            `base::system` = function(...) "no colors found!",
+
+            expect_equal(num_colors(forget = TRUE), 8)
+            )
+
+  # if tput returns a number the result is that number
+  with_mock(
+            `base::system` = function(...) "16",
+
+            expect_equal(num_colors(forget = TRUE), 16)
+            )
+})


### PR DESCRIPTION
Gábor,

The previous fix was not quite right, it needs to check that `cols` is not a 0 length character vector before checking for NA. The current code now generates `error: missing value where TRUE/FALSE needed`.

I had this fixed locally when I submitted the last pull request, but didn't realize I had forgotten to commit it, my apologies.