### PR TITLE
Get crayon to load in R session launched via emacs tramp

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -119,6 +119,7 @@ emacs_version <- function() {
   ver <- Sys.getenv("INSIDE_EMACS")
   if (ver == "") return(NA_integer_)
 
+  ver <- gsub("'", "", ver)
   ver <- strsplit(ver, ",", fixed = TRUE)[[1]]
   ver <- strsplit(ver, ".", fixed = TRUE)[[1]]
   as.numeric(ver)


### PR DESCRIPTION
The Emacs tramp package wraps the INSIDE_EMACS variable in single quotes, as seen [here.](http://git.savannah.gnu.org/cgit/tramp.git/tree/lisp/tramp-sh.el?id=f4c5c4ba8990f7d7c2243db86144969b0d4c004e#n475)

These quotes leads to the following error when loading crayon

    > library(crayon)
     Error : .onLoad failed in loadNamespace() for 'crayon', details:
       call: if (inside_emacs() && emacs_version()[1] >= 23) {
       error: missing value where TRUE/FALSE needed
     In addition: Warning message:
     In emacs_version() : NAs introduced by coercion
     Error: package or namespace load failed for ‘crayon’
   > 

This error also prevents the loading of packages that import crayon such as testthat. Seems safe to remove the single quotes, which eliminates all these errors.