### PR TITLE
Strsplittrail

### DIFF
--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -109,7 +109,7 @@ col_nchar <- function(x, ...) {
 
 col_substr <- function(x, start, stop) {
   ansi <- re_table(ansi_regex, x)
-  text <- non_matching(ansi, x)
+  text <- non_matching(ansi, x, empty=TRUE)
   mapper <- map_to_ansi(x, text = text)
   nstart <- mapper(start)
   nstop  <- mapper(stop)

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -214,6 +214,13 @@ col_strsplit <- function(x, split, ...) {
   plain <- strip_style(x)
   splits <- re_table(split, plain, ...)
   chunks <- non_matching(splits, plain, empty = TRUE)
+  # drop any zero length trailing chunks that are created when the split
+  # happens at end of string; this is to replicate 'substr' behavior
+  chunks <- lapply(
+    chunks,
+    function(y) if(nrow(y) > 1L && !tail(y, 1L)$length) head(y, -1L) else y
+  )
+  # Pull out chunks from colored string
   mapply(chunks, x, SIMPLIFY = FALSE, FUN = function(tab, xx)
     col_substring(xx, tab$start, tab$end))
 }

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -178,16 +178,15 @@ col_substring <- function(text, first, last = 1000000L) {
 #' Split an ANSI colored string
 #'
 #' This is the color-aware counterpart of \code{base::strsplit}.
-#' It works exactly like the original, but keeps the colors in the
+#' It works almost exactly like the original, but keeps the colors in the
 #' substrings.
 #'
 #' @param x Character vector, potentially ANSI styled, or a vector to
 #'   coarced to character.
-#' @param split Character vector (or object which can be coerced to such)
-#'   containing regular expression(s) (unless \code{fixed = TRUE}) to use for
-#'   splitting.  If empty matches occur, in particular if \code{split} has
-#'   length 0, \code{x} is split into single characters.  If \code{split} has
-#'   length greater than 1, it is re-cycled along \code{x}.
+#' @param split Character vector of length 1 (or object which can be coerced to
+#'   such) containing regular expression(s) (unless \code{fixed = TRUE}) to use
+#'   for splitting.  If empty matches occur, in particular if \code{split} has
+#'   zero characters, \code{x} is split into single characters.
 #' @param ... Extra arguments are passed to \code{base::strsplit}.
 #' @return A list of the same length as \code{x}, the \eqn{i}-th element of
 #'   which contains the vector of splits of \code{x[i]}. ANSI styles are
@@ -211,6 +210,10 @@ col_substring <- function(text, first, last = 1000000L) {
 #' strsplit(strip_style(str), "")
 
 col_strsplit <- function(x, split, ...) {
+  split <- try(as.character(split), silent=TRUE)
+  if(inherits(split, "try-error") || !is.character(split) || length(split) > 1L)
+    stop("`split` must be character of length <= 1, or must coerce to that")
+  if(!length(split)) split <- ""
   plain <- strip_style(x)
   splits <- re_table(split, plain, ...)
   chunks <- non_matching(splits, plain, empty = TRUE)

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -110,6 +110,12 @@ col_nchar <- function(x, ...) {
 col_substr <- function(x, start, stop) {
   if(!is.character(x)) x <- as.character(x)
   if(!length(x)) return(x)
+  start <- as.integer(start)
+  stop <- as.integer(stop)
+  if(!length(start) || !length(stop))
+    stop("invalid substring arguments")
+  if(anyNA(start) || anyNA(stop))
+    stop("non-numeric substring arguments not supported")
   ansi <- re_table(ansi_regex, x)
   text <- non_matching(ansi, x, empty=TRUE)
   mapper <- map_to_ansi(x, text = text)

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -219,10 +219,9 @@ col_strsplit <- function(x, split, ...) {
   plain <- strip_style(x)
   splits <- re_table(split, plain, ...)
   chunks <- non_matching(splits, plain, empty = TRUE)
-  # silently recycle `split`; note currently `re_table` doesn't use this but
-  # should eventually
-  split.r <- if(length(split) > length(x)) head(split, length(x)) else
-    head(rep(split, ceiling(length(x) / length(split))), length(x))
+  # silently recycle `split`; doesn't matter currently since we don't support
+  # split longer than 1, but might in future
+  split.r <- rep(split, length.out=length(x))
   # Drop empty chunks to align with `substr` behavior
   chunks <- lapply(
     seq_along(chunks),

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -6,7 +6,9 @@
 
 map_to_ansi <- function(x, text = NULL) {
 
-  if (is.null(text)) text <- non_matching(re_table(ansi_regex, x), x)
+  if (is.null(text)) {
+    text <- non_matching(re_table(ansi_regex, x), x, empty=TRUE)
+  }
 
   map <- lapply(
     text,

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -108,6 +108,8 @@ col_nchar <- function(x, ...) {
 #' substr(strip_style(c(str, str2)), c(3,5), c(7, 18))
 
 col_substr <- function(x, start, stop) {
+  if(!is.character(x)) x <- as.character(x)
+  if(!length(x)) return(x)
   ansi <- re_table(ansi_regex, x)
   text <- non_matching(ansi, x, empty=TRUE)
   mapper <- map_to_ansi(x, text = text)

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -219,9 +219,15 @@ col_strsplit <- function(x, split, ...) {
   chunks <- lapply(
     chunks,
     function(y)
-      if(nrow(y) > 1L && !tail(y, 1L)[, "length"]) head(y, -1L) else y
+      if(nrow(y) && !tail(y, 1L)[, "length"]) head(y, -1L) else y
   )
+  zero.chunks <- !vapply(chunks, nrow, integer(1L))
   # Pull out chunks from colored string
-  mapply(chunks, x, SIMPLIFY = FALSE, FUN = function(tab, xx)
-    col_substring(xx, tab[, "start"], tab[, "end"]))
+  res <- vector("list", length(chunks))
+  res[zero.chunks] <- list(character(0L))
+  res[!zero.chunks] <- mapply(
+    chunks[!zero.chunks], x[!zero.chunks], SIMPLIFY = FALSE,
+    FUN = function(tab, xx) col_substring(xx, tab[, "start"], tab[, "end"])
+  )
+  res
 }

--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -218,7 +218,8 @@ col_strsplit <- function(x, split, ...) {
   # happens at end of string; this is to replicate 'substr' behavior
   chunks <- lapply(
     chunks,
-    function(y) if(nrow(y) > 1L && !tail(y, 1L)$length) head(y, -1L) else y
+    function(y)
+      if(nrow(y) > 1L && !tail(y, 1L)[, "length"]) head(y, -1L) else y
   )
   # Pull out chunks from colored string
   mapply(chunks, x, SIMPLIFY = FALSE, FUN = function(tab, xx)

--- a/R/utils.r
+++ b/R/utils.r
@@ -90,8 +90,9 @@ non_matching <- function(table, str, empty = FALSE) {
       res <- data_frame(start = c(1, t$end + 1),
                         end = c(t$start - 1, base::nchar(s)))
       res$length <- res$end - res$start + 1
-      if (!empty) res[ res$length != 0, , drop = FALSE ]
-      res
+      if (!empty) {
+        res[ res$length != 0, , drop = FALSE ]
+      } else res
     }
   })
 }

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -15,11 +15,16 @@
 
 * Fix color detection in Emacs tramp
 
-* `col_strsplit` corner cases:
+* `col_strsplit` and `col_substr` corner cases:
+
     * handle empty chunks at beginning or end of strings
       like `base::strsplit` (@brodieG, #26)
+
     * explicitly deal with 'split' values that are not
       length 1 as that is not currently supported
+
+    * handle zero length `x` argument in `col_substr`, and
+      add more explicit error messages for corner cases
 
 * Some performance improvements to `col_substr` (@brodieG)
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -15,8 +15,11 @@
 
 * Fix color detection in Emacs tramp
 
-* `col_substr` no longer returns an empty chunk at end when strings end in
-  `split`; this aligns with `base::strsplit` (@brodieG, #26)
+* `col_strsplit` corner cases:
+    * handle empty chunks at beginning or end of strings
+      like `base::strsplit` (@brodieG, #26)
+    * explicitly deal with 'split' values that are not
+      length 1 as that is not currently supported
 
 * Some performance improvements to `col_substr` (@brodieG)
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -15,6 +15,9 @@
 
 * Fix color detection in Emacs tramp
 
+* `col_substr` no longer returns a chunk when strings end in
+  `split`; this aligns with `base::strsplit` (#26)
+
 # 1.3.1
 
 * Fixed some `R CMD check` problems.

--- a/man/col_strsplit.Rd
+++ b/man/col_strsplit.Rd
@@ -10,11 +10,10 @@ col_strsplit(x, split, ...)
 \item{x}{Character vector, potentially ANSI styled, or a vector to
 coarced to character.}
 
-\item{split}{Character vector (or object which can be coerced to such)
-containing regular expression(s) (unless \code{fixed = TRUE}) to use for
-splitting.  If empty matches occur, in particular if \code{split} has
-length 0, \code{x} is split into single characters.  If \code{split} has
-length greater than 1, it is re-cycled along \code{x}.}
+\item{split}{Character vector of length 1 (or object which can be coerced to
+such) containing regular expression(s) (unless \code{fixed = TRUE}) to use
+for splitting.  If empty matches occur, in particular if \code{split} has
+zero characters, \code{x} is split into single characters.}
 
 \item{...}{Extra arguments are passed to \code{base::strsplit}.}
 }
@@ -25,7 +24,7 @@ A list of the same length as \code{x}, the \eqn{i}-th element of
 }
 \description{
 This is the color-aware counterpart of \code{base::strsplit}.
-It works exactly like the original, but keeps the colors in the
+It works almost exactly like the original, but keeps the colors in the
 substrings.
 }
 \examples{

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -115,6 +115,15 @@ test_that("col_strsplit", {
   str.3 <- paste0("-", c(green("hello"), red("goodbye")), "-world-")
   expect_equal(strip_style(unlist(col_strsplit(str.3, "-"))),
                unlist(strsplit(strip_style(str.3), "-")))
+  # special cases
+  expect_equal(col_strsplit("", ""), strsplit("", ""))
+  expect_equal(col_strsplit("a", "a"), strsplit("a", "a"))
+  # this following test isn't working yet
+  # expect_equal(col_strsplit("a", ""), strsplit("a", ""))
+  expect_equal(col_strsplit("", "a"), strsplit("", "a"))
+
+
+
 })
 
 test_that("col_strsplit multiple strings", {
@@ -130,6 +139,9 @@ test_that("col_strsplit multiple strings", {
 
 test_that("col_strsplit empty string", {
 
-  expect_equal(col_strsplit("", "-"), list(""))
-  expect_equal(strip_style(col_strsplit("\033[31m\033[39m", "-")[[1]]), "")
+  ## these following tests have different behavior than `strsplit`, will need
+  ## to update once we work through issues
+
+  # expect_equal(col_strsplit("", "-"), list(""))
+  # expect_equal(strip_style(col_strsplit("\033[31m\033[39m", "-")[[1]]), "")
 })

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -147,3 +147,11 @@ test_that("col_strsplit edge cases", {
     col_strsplit(c("abaa", "ababza"), "b."), strsplit(c("abaa", "ababza"), "b.")
   )
 })
+
+test_that("Weird length 'split'", {
+  expect_error(col_strsplit(c("ab", "bd"), c("b", "d")), "must be character")
+  expect_identical(col_strsplit("ab", NULL), strsplit("ab", NULL))
+  expect_identical(
+    col_strsplit("ab", character(0L)), strsplit("ab", character(0L))
+  )
+})

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -106,6 +106,15 @@ test_that("col_strsplit", {
   expect_equal(strip_style(col_strsplit(str, "-")[[1]]),
                strsplit(strip_style(str), "-")[[1]])
   
+  # with leading and trailing separators
+  str.2 <- "-" %+% red %+% "-" %+% red %+% "-" %+% red %+% "-"
+  expect_equal(strip_style(col_strsplit(str.2, "-")[[1]]),
+               strsplit(strip_style(str.2), "-")[[1]])
+
+  # greater than length 1
+  str.3 <- paste0("-", c(green("hello"), red("goodbye")), "-world-")
+  expect_equal(strip_style(unlist(col_strsplit(str.3, "-"))),
+               unlist(strsplit(strip_style(str.3), "-")))
 })
 
 test_that("col_strsplit multiple strings", {

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -115,15 +115,6 @@ test_that("col_strsplit", {
   str.3 <- paste0("-", c(green("hello"), red("goodbye")), "-world-")
   expect_equal(strip_style(unlist(col_strsplit(str.3, "-"))),
                unlist(strsplit(strip_style(str.3), "-")))
-  # special cases
-  expect_equal(col_strsplit("", ""), strsplit("", ""))
-  expect_equal(col_strsplit("a", "a"), strsplit("a", "a"))
-  # this following test isn't working yet
-  # expect_equal(col_strsplit("a", ""), strsplit("a", ""))
-  expect_equal(col_strsplit("", "a"), strsplit("", "a"))
-
-
-
 })
 
 test_that("col_strsplit multiple strings", {
@@ -137,11 +128,22 @@ test_that("col_strsplit multiple strings", {
   
 })
 
-test_that("col_strsplit empty string", {
-
-  ## these following tests have different behavior than `strsplit`, will need
-  ## to update once we work through issues
-
-  # expect_equal(col_strsplit("", "-"), list(""))
-  # expect_equal(strip_style(col_strsplit("\033[31m\033[39m", "-")[[1]]), "")
+test_that("col_strsplit edge cases", {
+  expect_equal(col_strsplit("", "-"), list(character(0L)))
+  expect_equal(
+    strip_style(col_strsplit("\033[31m\033[39m", "-")[[1]]), character(0L)
+  )
+  # special cases
+  expect_equal(col_strsplit("", ""), strsplit("", ""))
+  expect_equal(col_strsplit("a", "a"), strsplit("a", "a"))
+  # this following test isn't working yet
+  expect_equal(col_strsplit("a", ""), strsplit("a", ""))
+  expect_equal(col_strsplit("", "a"), strsplit("", "a"))
+  # Longer strings
+  expect_identical(
+    col_strsplit(c("", "a", "aa"), "a"), strsplit(c("", "a", "aa"), "a")
+  )
+  expect_identical(
+    col_strsplit(c("abaa", "ababza"), "b."), strsplit(c("abaa", "ababza"), "b.")
+  )
 })

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -64,6 +64,30 @@ test_that("col_substr, multiple strings", {
   }
 })
 
+test_that("col_substr corner cases", {
+  # Zero length input
+
+  c0 <- character(0L)
+  o0 <- structure(list(), class="abc")
+  co0 <- structure(character(0L), class="abc")
+  expect_identical(col_substr(c0, 1, 1), substr(c0, 1, 1))
+  expect_identical(col_substr(o0, 1, 1), substr(o0, 1, 1))
+  expect_identical(col_substr(co0, 1, 1), substr(co0, 1, 1))
+
+  expect_identical(col_substring(c0, 1, 1), substring(c0, 1, 1))
+  expect_identical(col_substring(o0, 1, 1), substring(o0, 1, 1))
+  expect_identical(col_substring(co0, 1, 1), substring(co0, 1, 1))
+
+  # Character start/stop
+  expect_identical(col_substr("abc", "1", 1), substr("abc", "1", 1))
+  expect_identical(col_substr("abc", 1, "1"), substr("abc", 1, "1"))
+
+  # non-numeric arguments cause errors; NOTE: this actually "works" 
+  # with 'substr' but not implemented in 'col_substr'
+  expect_error(col_substr("abc", "hello", 1), "non-numeric")
+
+})
+
 test_that("col_substring", {
   for (s in str) {
     for (i in 1 %:% col_nchar(s)) {
@@ -89,14 +113,12 @@ test_that("col_substring, multiple strings", {
   }
 })
 
-test_that("col_substr, col_strsplit, zero length input", {
+test_that("col_substring corner cases", {
+  # Zero length input
+
   c0 <- character(0L)
   o0 <- structure(list(), class="abc")
   co0 <- structure(character(0L), class="abc")
-  expect_identical(col_substr(c0, 1, 1), substr(c0, 1, 1))
-  expect_identical(col_substr(o0, 1, 1), substr(o0, 1, 1))
-  expect_identical(col_substr(co0, 1, 1), substr(co0, 1, 1))
-
   expect_identical(col_substring(c0, 1, 1), substring(c0, 1, 1))
   expect_identical(col_substring(o0, 1, 1), substring(o0, 1, 1))
   expect_identical(col_substring(co0, 1, 1), substring(co0, 1, 1))

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -89,6 +89,19 @@ test_that("col_substring, multiple strings", {
   }
 })
 
+test_that("col_substr, col_strsplit, zero length input", {
+  c0 <- character(0L)
+  o0 <- structure(list(), class="abc")
+  co0 <- structure(character(0L), class="abc")
+  expect_identical(col_substr(c0, 1, 1), substr(c0, 1, 1))
+  expect_identical(col_substr(o0, 1, 1), substr(o0, 1, 1))
+  expect_identical(col_substr(co0, 1, 1), substr(co0, 1, 1))
+
+  expect_identical(col_substring(c0, 1, 1), substring(c0, 1, 1))
+  expect_identical(col_substring(o0, 1, 1), substring(o0, 1, 1))
+  expect_identical(col_substring(co0, 1, 1), substring(co0, 1, 1))
+})
+
 test_that("col_strsplit", {
   red <- "\033[31mred\033[39m"
   

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,9 @@
+context("utils")
+
+test_that("non_matching", {
+  chr <- "abc"
+  splits <- crayon:::re_table("", chr)
+  res.df <- data.frame(start=c(1L, 1L:3L), end=0L:3L, length=c(0L, 1L, 1L, 1L))
+  expect_equal(crayon:::non_matching(splits, chr, empty=TRUE)[[1L]], res.df)
+  expect_equal(crayon:::non_matching(splits, chr)[[1L]], res.df[-1L,])
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -3,7 +3,7 @@ context("utils")
 test_that("non_matching", {
   chr <- "abc"
   splits <- crayon:::re_table("", chr)
-  res.df <- data.frame(start=c(1L, 1L:3L), end=0L:3L, length=c(0L, 1L, 1L, 1L))
-  expect_equal(crayon:::non_matching(splits, chr, empty=TRUE)[[1L]], res.df)
-  expect_equal(crayon:::non_matching(splits, chr)[[1L]], res.df[-1L,])
+  res.mx <- cbind(start=c(1L, 1L:3L), end=0L:3L, length=c(0L, 1L, 1L, 1L))
+  expect_equal(crayon:::non_matching(splits, chr, empty=TRUE)[[1L]], res.mx)
+  expect_equal(crayon:::non_matching(splits, chr)[[1L]], res.mx[-1L,])
 })


### PR DESCRIPTION
Proposed "fix" for #26 (Fixes #26).  A few noteworthy comments:

* I "fixed" this issue only in `col_strsplit`.  It could potentially be "fixed" in `crayon:::re_table` which would be cleaner, but would affect multiple other functions
* I also enabled the `empty` parameter for `non_matching`; since it wasn't being used (I think), I updated all calls to that function to specify `empty=TRUE` to avoid changing behavior

Let me know if you want me to change / revert any of this.