### PR TITLE
Optimize Internal Char Mapping Functions

### DIFF
--- a/R/string_operations.r
+++ b/R/string_operations.r
@@ -11,9 +11,9 @@ map_to_ansi <- function(x, text = NULL) {
   map <- lapply(
     text,
     function(text) {
-      data.frame(
-        pos = cumsum(c(1, text$length, Inf)),
-        offset = c(text$start - 1, tail(text$end, 1), NA)
+      cbind(
+        pos = cumsum(c(1, text[, "length"], Inf)),
+        offset = c(text[, "start"] - 1, tail(text[, "end"], 1), NA)
       )
     })
 
@@ -23,8 +23,8 @@ map_to_ansi <- function(x, text = NULL) {
       if (pos < 1) {
         pos
       } else {
-        slot <- which(pos < table$pos)[1] - 1
-        table$offset[slot] + pos - table$pos[slot] + 1
+        slot <- which(pos < table[, "pos"])[1] - 1
+        table[slot, "offset"] + pos - table[slot, "pos"] + 1
       }
     })
   }
@@ -213,5 +213,5 @@ col_strsplit <- function(x, split, ...) {
   splits <- re_table(split, plain, ...)
   chunks <- non_matching(splits, plain, empty = TRUE)
   mapply(chunks, x, SIMPLIFY = FALSE, FUN = function(tab, xx)
-    col_substring(xx, tab$start, tab$end))
+    col_substring(xx, tab[, "start"], tab[, "end"]))
 }

--- a/R/utils.r
+++ b/R/utils.r
@@ -71,12 +71,12 @@ multicol <- function(x) {
 
 re_table <- function(...) {
   lapply(gregexpr(...), function(x) {
-    res <- data_frame(
+    res <- cbind(
       start = x,
       end = x + attr(x, "match.length") - 1,
       length = attr(x, "match.length")
     )
-    res <- res[res$start != -1, ]
+    res <- res[res[, "start"] != -1, , drop=FALSE]
   })
 }
 
@@ -85,12 +85,12 @@ re_table <- function(...) {
 non_matching <- function(table, str, empty = FALSE) {
   mapply(table, str, SIMPLIFY = FALSE, FUN = function(t, s) {
     if (! nrow(t)) {
-      data_frame(start = 1, end = base::nchar(s), length = base::nchar(s))
+      cbind(start = 1, end = base::nchar(s), length = base::nchar(s))
     } else {
-      res <- data_frame(start = c(1, t$end + 1),
-                        end = c(t$start - 1, base::nchar(s)))
-      res$length <- res$end - res$start + 1
-      if (!empty) res[ res$length != 0, , drop = FALSE ]
+      start <- c(1, t[, "end"] + 1)
+      end <- c(t[, "start"] - 1, base::nchar(s))
+      res <- cbind(start = start, end = end, length = end - start + 1)
+      if (!empty) res[ res[, "length"] != 0, , drop = FALSE ]
       res
     }
   })

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -15,6 +15,8 @@
 
 * Fix color detection in Emacs tramp
 
+* Some performance improvements to `col_substr`
+
 # 1.3.1
 
 * Fixed some `R CMD check` problems.


### PR DESCRIPTION
Improves performance of `col_substr` and `col_strsplit`.  Changed data frames to matrices, which doesn't appear to break anything and gives some decent speed improvements, on the order of 7x on [some simple tests](https://gist.github.com/brodieG/6f92827213388d54fb67).

I can easily merge this into the other PR if you wish.  There are are a couple of conflicts.  Making a separate PR since it really is a separate issue, but I have a [merged branch available as well](https://github.com/brodieG/crayon/tree/brodie).

Probably could come up with further optimizations, but these are minimally intrusive and produce enough improvements that they seemed worth the trouble.