### PR TITLE
Remove duplicate operation in `emacs_version`

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -121,7 +121,6 @@ emacs_version <- function() {
   ver <- gsub("'", "", ver)
   ver <- strsplit(ver, ",", fixed = TRUE)[[1]]
   ver <- strsplit(ver, ".", fixed = TRUE)[[1]]
-  ver <- gsub("'", "", ver)
   as.numeric(ver)
 }
 


### PR DESCRIPTION
The two `gsub("'", "", ver)`s were introduced in pull requests #1 and and #23. Only one is needed, since it removes all single quotes from the string.