### PR TITLE
fix inside_emacs()

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -125,7 +125,7 @@ emacs_version <- function() {
 }
 
 inside_emacs <- function() {
-  Sys.getenv("EMACS") != ""
+  Sys.getenv("INSIDE_EMACS") != ""
 }
 
 rstudio_with_ansi_support <- function() {

--- a/R/utils.r
+++ b/R/utils.r
@@ -125,7 +125,7 @@ emacs_version <- function() {
 }
 
 inside_emacs <- function() {
-  Sys.getenv("INSIDE_EMACS") != ""
+    Sys.getenv("EMACS") != "" || Sys.getenv("INSIDE_EMACS") != ""
 }
 
 rstudio_with_ansi_support <- function() {


### PR DESCRIPTION
Since I upgraded to Ubuntu 17.04 with Emacs 25.1.1 (with ess from elpa 20170501.306), I noticed that crayon stopped coloring.

It seems that there the environment variable `EMACS` is not set:

```r
> Sys.getenv("EMACS")
[1] ""
```

Using the `INSIDE_EMACS` instead brings the coloring back.
