### PR TITLE
Use %+% instead of \%+\% in roxygen documentation

### DIFF
--- a/R/machinery.r
+++ b/R/machinery.r
@@ -263,14 +263,14 @@ make_crayon <- function(ansi_seq) {
 #' @examples
 #' cat(blue("Hello", "world!"))
 #'
-#' cat("... to highlight the " \%+\% red("search term") \%+\%
+#' cat("... to highlight the " %+% red("search term") %+%
 #'     " in a block of text")
 #'
 #' cat(yellow$bgMagenta$bold('Hello world!'))
 #'
 #' cat(green(
-#'  'I am a green line ' \%+\%
-#'  blue$underline$bold('with a blue substring') \%+\%
+#'  'I am a green line ' %+%
+#'  blue$underline$bold('with a blue substring') %+%
 #'  ' that becomes green again!'
 #' ))
 #'

--- a/man/crayon.Rd
+++ b/man/crayon.Rd
@@ -135,14 +135,14 @@ It is easy to define your own themes: \preformatted{  error <- red $ bold
 \examples{
 cat(blue("Hello", "world!"))
 
-cat("... to highlight the " \\\%+\\\% red("search term") \\\%+\\\%
+cat("... to highlight the " \%+\% red("search term") \%+\%
     " in a block of text")
 
 cat(yellow$bgMagenta$bold('Hello world!'))
 
 cat(green(
- 'I am a green line ' \\\%+\\\%
- blue$underline$bold('with a blue substring') \\\%+\\\%
+ 'I am a green line ' \%+\%
+ blue$underline$bold('with a blue substring') \%+\%
  ' that becomes green again!'
 ))
 


### PR DESCRIPTION
So that we have the intended code in the manual, i.e. 

```
cat(green(
 'I am a green line ' %+%
 blue$underline$bold('with a blue substring') %+%
 ' that becomes green again!'
))
```

